### PR TITLE
SCRUM-449: Fix Payment public_id default_factory=uuid4

### DIFF
--- a/app/models/payment.py
+++ b/app/models/payment.py
@@ -28,7 +28,7 @@ class PaymentUpdate(PaymentMutable):
 
 
 class PaymentInmutable(SQLModel):
-    public_id: UUID = Field(default=uuid4(), unique=True)
+    public_id: UUID = Field(default_factory=uuid4, unique=True)
 
 
 class Payment(PaymentBase, PaymentInmutable, PaymentMutable, table=True):


### PR DESCRIPTION
- Fix: In `Payment.public_id`, change `default=uuid4()` to `default_factory=uuid4`